### PR TITLE
Fixes crash on dedicated server in 1.19.2

### DIFF
--- a/src/main/java/net/hadrus/alcocraft/events/AlcoCraftClientEvents.java
+++ b/src/main/java/net/hadrus/alcocraft/events/AlcoCraftClientEvents.java
@@ -1,0 +1,17 @@
+package net.hadrus.alcocraft.events;
+
+import net.hadrus.alcocraft.AlcoCraftPlus;
+import net.hadrus.alcocraft.particles.AlcoParticles;
+import net.hadrus.alcocraft.particles.YellowBubbleParticles;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = AlcoCraftPlus.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class AlcoCraftClientEvents {
+    @SubscribeEvent
+    public static void registerParticleFactories(final RegisterParticleProvidersEvent event) {
+        event.register(AlcoParticles.YELLOW_BUBBLES.get(), YellowBubbleParticles.Provider::new);
+    }
+}

--- a/src/main/java/net/hadrus/alcocraft/events/AlcoCraftEvents.java
+++ b/src/main/java/net/hadrus/alcocraft/events/AlcoCraftEvents.java
@@ -3,10 +3,7 @@ package net.hadrus.alcocraft.events;
 import net.hadrus.alcocraft.AlcoCraftPlus;
 import net.hadrus.alcocraft.loot.DungeonChests;
 import net.hadrus.alcocraft.loot.HopSeeds;
-import net.hadrus.alcocraft.particles.AlcoParticles;
-import net.hadrus.alcocraft.particles.YellowBubbleParticles;
 import net.hadrus.alcocraft.recipes.KegRecipe;
-import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -19,11 +16,6 @@ public class AlcoCraftEvents  {
         event.register(ForgeRegistries.Keys.RECIPE_TYPES, (helper) -> {
             event.getForgeRegistry().register(KegRecipe.Type.ID, KegRecipe.Type.INSTANCE);
         });
-    }
-
-    @SubscribeEvent
-    public static void registerParticleFactories(final RegisterParticleProvidersEvent event) {
-        event.register(AlcoParticles.YELLOW_BUBBLES.get(), YellowBubbleParticles.Provider::new);
     }
 
     @SubscribeEvent

--- a/src/main/java/net/hadrus/alcocraft/misc/AlcoTags.java
+++ b/src/main/java/net/hadrus/alcocraft/misc/AlcoTags.java
@@ -1,6 +1,6 @@
 package net.hadrus.alcocraft.misc;
 
-import net.hadrus.alcocraft.AlcoCraft;
+import net.hadrus.alcocraft.AlcoCraftPlus;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
@@ -12,7 +12,7 @@ public class AlcoTags {
         public static final TagKey<Item> BEER_MUGS = tag("beer_mugs");
 
         private static TagKey<Item> tag(String name) {
-            return ItemTags.create(new ResourceLocation(AlcoCraft.MOD_ID, name));
+            return ItemTags.create(new ResourceLocation(AlcoCraftPlus.MOD_ID, name));
         }
 
         private static TagKey<Item> forgeTag(String name) {


### PR DESCRIPTION
Fixes crash caused by `RegisterParticleProvidersEvent` being called on dedicated server.